### PR TITLE
fix(docs): forkUrk -> forkUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import { createAnvil } from "@viem/anvil"
 
 // All options are supported & typed.
 const anvil = createAnvil({
-  forkUrk: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
+  forkUrl: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
   blockNumber: 12345678,
 });
 ```
@@ -74,7 +74,7 @@ import { createProxy, createPool } from "@viem/anvil";
 const server = const createProxy({
   pool: createPool<number>(),
   options: {
-    forkUrk: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
+    forkUrl: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
     blockNumber: 12345678,
   },
 });
@@ -119,7 +119,7 @@ import { startProxy } from "@viem/anvil";
 const shutdown = await startProxy({
   port: 8555,
   options: {
-    forkUrk: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
+    forkUrl: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
     blockNumber: 12345678,
   },
 });

--- a/packages/anvil.js/src/proxy/createProxy.ts
+++ b/packages/anvil.js/src/proxy/createProxy.ts
@@ -30,7 +30,7 @@ export type CreateProxyOptions = {
  * const server = const createProxy({
  *   pool: createPool<number>(),
  *   options: {
- *     forkUrk: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
+ *     forkUrl: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
  *     blockNumber: 12345678,
  *   },
  * });

--- a/packages/anvil.js/src/proxy/startProxy.ts
+++ b/packages/anvil.js/src/proxy/startProxy.ts
@@ -39,7 +39,7 @@ export type StartProxyOptions = {
  * const shutdown = await startProxy({
  *   port: 8555,
  *   options: {
- *     forkUrk: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
+ *     forkUrl: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",
  *     blockNumber: 12345678,
  *   },
  * });


### PR DESCRIPTION
typo

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `forkUrk` variable to `forkUrl` in multiple files.

### Detailed summary
- Replaced `forkUrk` with `forkUrl` in `startProxy.ts` and `createProxy.ts`
- Updated `forkUrk` to `forkUrl` in `README.md` and `index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->