### PR TITLE
fix: typo in error message

### DIFF
--- a/packages/anvil.js/src/proxy/createProxy.ts
+++ b/packages/anvil.js/src/proxy/createProxy.ts
@@ -140,7 +140,7 @@ export function createProxy({ pool, options, fallback }: CreateProxyOptions) {
 
             return sendFailure(res, {
               code: 404,
-              reason: `Anvil instance doesn't exists`,
+              reason: `Anvil instance doesn't exist`,
             });
           }
         }


### PR DESCRIPTION
Spotted a minor typo whilst running this locally

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a typo in an error message in `createProxy.ts` file.

### Detailed summary
- Fixed a typo in the error message. `Anvil instance doesn't exists` changed to `Anvil instance doesn't exist`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->