### PR TITLE
fix: start proxy in cjs

### DIFF
--- a/.changeset/moody-zebras-change.md
+++ b/.changeset/moody-zebras-change.md
@@ -1,0 +1,5 @@
+---
+"@viem/anvil": patch
+---
+
+Fixed import from `http-proxy` package in cjs environments.

--- a/examples/example-node/index.ts
+++ b/examples/example-node/index.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert";
 import { test } from "node:test";
-import { createAnvil, getVersion } from "@viem/anvil";
+import { createAnvil, createPool, getVersion, startProxy } from "@viem/anvil";
 
 test("can fetch the anvil version", async () => {
   const version = await getVersion();
@@ -20,4 +20,27 @@ test("can start and stop anvil instances", async () => {
   assert(anvil.status === "listening");
   await anvil.stop();
   assert((anvil.status as string) === "idle");
+});
+
+test("can start and stop pool instances", async () => {
+  const pool = createPool();
+
+  const a = await pool.start(1);
+  assert(a !== undefined);
+  assert(a.status === "listening");
+
+  const b = await pool.start(123);
+  assert(b !== undefined);
+  assert(b.status === "listening");
+
+  await a.stop();
+  assert((a.status as string) === "idle");
+
+  await b.stop();
+  assert((b.status as string) === "idle");
+});
+
+test("can start and stop an anvil proxy", async () => {
+  const stop = await startProxy();
+  await stop();
 });

--- a/packages/anvil.js/src/proxy/createProxy.ts
+++ b/packages/anvil.js/src/proxy/createProxy.ts
@@ -1,4 +1,4 @@
-import httpProxy from "http-proxy";
+import { createProxyServer } from "http-proxy";
 import { IncomingMessage, ServerResponse, createServer } from "node:http";
 import { parseRequest, type InstanceRequestContext } from "./parseRequest.js";
 import { type Pool } from "../pool/createPool.js";
@@ -77,7 +77,7 @@ export type CreateProxyOptions = {
  * ```
  */
 export function createProxy({ pool, options, fallback }: CreateProxyOptions) {
-  const proxy = httpProxy.createProxyServer({
+  const proxy = createProxyServer({
     ignorePath: true,
     ws: true,
   });


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `http-proxy` import in `createProxy.ts` file to be compatible with CommonJS (cjs) environments. It also adds new tests to check the functionality of `createPool()` and `startProxy()` functions.

### Detailed summary
- Fixed import from `http-proxy` package in cjs environments.
- Added tests to check the functionality of `createPool()` and `startProxy()` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->