### PR TITLE
chore: organize imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
   "editor.defaultFormatter": "rome.rome",
   "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.rome": true
+  },
   "[typescript]": {
     "editor.defaultFormatter": "rome.rome"
   },

--- a/.vscode/workspace.code-workspace
+++ b/.vscode/workspace.code-workspace
@@ -16,6 +16,9 @@
   "settings": {
     "editor.defaultFormatter": "rome.rome",
     "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports.rome": true
+    },
     "[typescript]": {
       "editor.defaultFormatter": "rome.rome"
     },

--- a/examples/example-node/index.ts
+++ b/examples/example-node/index.ts
@@ -1,6 +1,6 @@
+import { createAnvil, createPool, getVersion, startProxy } from "@viem/anvil";
 import assert from "node:assert";
 import { test } from "node:test";
-import { createAnvil, createPool, getVersion, startProxy } from "@viem/anvil";
 
 test("can fetch the anvil version", async () => {
   const version = await getVersion();

--- a/examples/example-vitest/src/anotherTest.test.ts
+++ b/examples/example-vitest/src/anotherTest.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "vitest";
-import { publicClient } from "../tests/utils.js";
 import { FORK_BLOCK_NUMBER } from "../tests/constants.js";
+import { publicClient } from "../tests/utils.js";
+import { expect, test } from "vitest";
 
 test("vitest runs this test in parallel to the other", async () => {
   // NOTE: This test is run concurrently with the `wagmiContract` test file.

--- a/examples/example-vitest/src/wagmiContract.test.ts
+++ b/examples/example-vitest/src/wagmiContract.test.ts
@@ -1,8 +1,8 @@
-import { beforeAll, expect, test } from "vitest";
+import { ALICE, BOB } from "../tests/constants.js";
 import { publicClient, walletClient } from "../tests/utils.js";
 import { wagmiContract } from "./wagmiContract.js";
-import { ALICE, BOB } from "../tests/constants.js";
-import { isAddress, type Address } from "viem";
+import { type Address, isAddress } from "viem";
+import { beforeAll, expect, test } from "vitest";
 
 let wagmi: Address;
 beforeAll(async () => {

--- a/examples/example-vitest/tests/globalSetup.ts
+++ b/examples/example-vitest/tests/globalSetup.ts
@@ -1,5 +1,5 @@
-import { startProxy } from "@viem/anvil";
 import { FORK_BLOCK_NUMBER, FORK_URL } from "./constants.js";
+import { startProxy } from "@viem/anvil";
 
 export default async function () {
   return await startProxy({

--- a/examples/example-vitest/tests/setup.ts
+++ b/examples/example-vitest/tests/setup.ts
@@ -1,7 +1,7 @@
+import { FORK_BLOCK_NUMBER, FORK_URL } from "./constants.js";
+import { pool, testClient } from "./utils.js";
 import { fetchLogs } from "@viem/anvil";
 import { afterAll, afterEach } from "vitest";
-import { pool, testClient } from "./utils.js";
-import { FORK_BLOCK_NUMBER, FORK_URL } from "./constants.js";
 
 afterAll(async () => {
   // If you are using a fork, you can reset your anvil instance to the initial fork block.

--- a/examples/example-vitest/tests/utils.ts
+++ b/examples/example-vitest/tests/utils.ts
@@ -1,11 +1,11 @@
-import { mainnet } from "viem/chains";
 import {
-  createTestClient,
-  createPublicClient,
   type Chain,
-  http,
+  createPublicClient,
+  createTestClient,
   createWalletClient,
+  http,
 } from "viem";
+import { mainnet } from "viem/chains";
 
 /**
  * The id of the current test worker.

--- a/packages/anvil.js/src/anvil/createAnvil.test.ts
+++ b/packages/anvil.js/src/anvil/createAnvil.test.ts
@@ -1,11 +1,11 @@
-import getPort from "get-port";
-import { test, vi, expect, afterEach } from "vitest";
 import { createAnvilClients } from "../../tests/utils/utils.js";
 import {
-  createAnvil as createAnvilBase,
   type Anvil,
   type CreateAnvilOptions,
+  createAnvil as createAnvilBase,
 } from "./createAnvil.js";
+import getPort from "get-port";
+import { afterEach, expect, test, vi } from "vitest";
 
 const instances: Anvil[] = [];
 

--- a/packages/anvil.js/src/anvil/createAnvil.ts
+++ b/packages/anvil.js/src/anvil/createAnvil.ts
@@ -1,8 +1,8 @@
-import type { ExecaChildProcess } from "execa";
-import { Writable } from "node:stream";
-import { EventEmitter } from "node:events";
-import { toArgs } from "./toArgs.js";
 import { stripColors } from "./stripColors.js";
+import { toArgs } from "./toArgs.js";
+import type { ExecaChildProcess } from "execa";
+import { EventEmitter } from "node:events";
+import { Writable } from "node:stream";
 
 /**
  * An anvil instance.

--- a/packages/anvil.js/src/anvil/getVersion.test.ts
+++ b/packages/anvil.js/src/anvil/getVersion.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "vitest";
 import { getVersion } from "./getVersion.js";
+import { expect, test } from "vitest";
 
 test("returns a valid version string", async () => {
   const version = await getVersion();

--- a/packages/anvil.js/src/anvil/toArgs.test.ts
+++ b/packages/anvil.js/src/anvil/toArgs.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { toArgs } from "./toArgs.js";
+import { expect, test } from "vitest";
 
 test.each([
   [{}, []],

--- a/packages/anvil.js/src/anvil/toFlagCase.test.ts
+++ b/packages/anvil.js/src/anvil/toFlagCase.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { toFlagCase } from "./toFlagCase.js";
+import { expect, test } from "vitest";
 
 test.each([
   ["foo", "--foo"],

--- a/packages/anvil.js/src/pool/createPool.test.ts
+++ b/packages/anvil.js/src/pool/createPool.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, beforeEach } from "vitest";
-import { createPool, type Pool } from "./createPool.js";
 import { createAnvilClients } from "../../tests/utils/utils.js";
+import { type Pool, createPool } from "./createPool.js";
+import { beforeEach, expect, test } from "vitest";
 
 let pool: Pool;
 

--- a/packages/anvil.js/src/pool/createPool.ts
+++ b/packages/anvil.js/src/pool/createPool.ts
@@ -1,9 +1,9 @@
-import getPort from "get-port";
 import {
-  createAnvil,
   type Anvil,
   type CreateAnvilOptions,
+  createAnvil,
 } from "../anvil/createAnvil.js";
+import getPort from "get-port";
 
 /**
  * A pool of anvil instances.

--- a/packages/anvil.js/src/proxy/createProxy.test.ts
+++ b/packages/anvil.js/src/proxy/createProxy.test.ts
@@ -1,7 +1,7 @@
-import getPort from "get-port";
-import { test, expect, afterEach } from "vitest";
 import { createProxyClients } from "../../tests/utils/utils.js";
-import { startProxy, type StartProxyOptions } from "./startProxy.js";
+import { type StartProxyOptions, startProxy } from "./startProxy.js";
+import getPort from "get-port";
+import { afterEach, expect, test } from "vitest";
 
 const cleanup: (() => Promise<void>)[] = [];
 

--- a/packages/anvil.js/src/proxy/createProxy.ts
+++ b/packages/anvil.js/src/proxy/createProxy.ts
@@ -1,9 +1,9 @@
+import type { CreateAnvilOptions } from "../anvil/createAnvil.js";
+import { type Pool } from "../pool/createPool.js";
+import { type InstanceRequestContext, parseRequest } from "./parseRequest.js";
 import { createProxyServer } from "http-proxy";
 import { IncomingMessage, ServerResponse, createServer } from "node:http";
-import { parseRequest, type InstanceRequestContext } from "./parseRequest.js";
-import { type Pool } from "../pool/createPool.js";
 import type { Awaitable } from "vitest";
-import type { CreateAnvilOptions } from "../anvil/createAnvil.js";
 
 // rome-ignore lint/nursery/noBannedTypes: this is fine ...
 export type ProxyResponseSuccess<TResponse extends object = {}> = {

--- a/packages/anvil.js/src/proxy/fetchLogs.test.ts
+++ b/packages/anvil.js/src/proxy/fetchLogs.test.ts
@@ -1,8 +1,8 @@
-import { beforeAll, afterEach, expect, test } from "vitest";
-import { startProxy } from "./startProxy.js";
-import getPort from "get-port";
 import { createPool } from "../pool/createPool.js";
 import { fetchLogs } from "./fetchLogs.js";
+import { startProxy } from "./startProxy.js";
+import getPort from "get-port";
+import { afterEach, beforeAll, expect, test } from "vitest";
 
 const pool = createPool();
 afterEach(async () => {

--- a/packages/anvil.js/src/proxy/parseRequest.test.ts
+++ b/packages/anvil.js/src/proxy/parseRequest.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "vitest";
 import { parseRequest } from "./parseRequest.js";
+import { expect, test } from "vitest";
 
 test.each([
   ["", undefined],

--- a/packages/anvil.js/src/proxy/startProxy.ts
+++ b/packages/anvil.js/src/proxy/startProxy.ts
@@ -1,6 +1,6 @@
+import { type Pool, createPool } from "../pool/createPool.js";
+import { type CreateProxyOptions, createProxy } from "./createProxy.js";
 import { Server } from "node:http";
-import { createProxy, type CreateProxyOptions } from "./createProxy.js";
-import { createPool, type Pool } from "../pool/createPool.js";
 
 export type StartProxyOptions = Omit<CreateProxyOptions, "pool"> & {
   /**

--- a/packages/anvil.js/tests/proxyWorkbench.test.ts
+++ b/packages/anvil.js/tests/proxyWorkbench.test.ts
@@ -1,6 +1,6 @@
-import { afterAll, expect, test } from "vitest";
-import { createProxyClients } from "./utils/utils.js";
 import { FORK_BLOCK_NUMBER, FORK_URL } from "./utils/constants.js";
+import { createProxyClients } from "./utils/utils.js";
+import { afterAll, expect, test } from "vitest";
 
 const clients = createProxyClients([1, 2, 3]);
 

--- a/packages/anvil.js/tests/utils/utils.ts
+++ b/packages/anvil.js/tests/utils/utils.ts
@@ -1,12 +1,12 @@
+import type { Anvil } from "../../src/anvil/createAnvil.js";
 import {
-  createTestClient,
-  createPublicClient,
   type Chain,
-  http,
+  createPublicClient,
+  createTestClient,
   createWalletClient,
+  http,
 } from "viem";
 import { localhost } from "viem/chains";
-import type { Anvil } from "../../src/anvil/createAnvil.js";
 
 type TupleOf<T, N extends number, R extends unknown[]> = R["length"] extends N
   ? R

--- a/rome.json
+++ b/rome.json
@@ -12,5 +12,8 @@
     "rules": {
       "all": true
     }
+  },
+  "organizeImports": {
+    "enabled": true
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds `vitest` as a testing library and enables `organizeImports` in VS Code. It also imports `getPort` and `InstanceRequestContext` and changes some type imports. 

### Detailed summary
- Adds `vitest` testing library to multiple test files.
- Enables `organizeImports` in VS Code.
- Imports `getPort` in multiple files.
- Imports `InstanceRequestContext` in `createProxy.ts`.
- Changes some type imports.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->