### PR TITLE
fix: cjs & esm support for http-proxy

### DIFF
--- a/.changeset/tiny-zebras-impress.md
+++ b/.changeset/tiny-zebras-impress.md
@@ -1,0 +1,5 @@
+---
+"@viem/anvil": patch
+---
+
+Fixed `http-proxy` import for both cjs & esm

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Creates and starts a proxy server that spawns anvil instance on demand (e.g. per
 ```ts
 import { createProxy, createPool } from "@viem/anvil";
 
-const server = const createProxy({
+const server = await createProxy({
   pool: createPool(),
   options: {
     forkUrl: "https://eth-mainnet.alchemyapi.io/v2/<API_KEY>",

--- a/packages/anvil.js/src/proxy/startProxy.ts
+++ b/packages/anvil.js/src/proxy/startProxy.ts
@@ -49,7 +49,7 @@ export async function startProxy({
 }: StartProxyOptions = {}) {
   // rome-ignore lint/suspicious/noAsyncPromiseExecutor: this is fine ...
   const server = await new Promise<Server>(async (resolve, reject) => {
-    const server = createProxy({ pool, ...rest });
+    const server = await createProxy({ pool, ...rest });
 
     server.on("listening", () => resolve(server));
     server.on("error", (error) => reject(error));


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes an import issue with `http-proxy` in the `@viem/anvil` package.

### Detailed summary
- Fixes `http-proxy` import for both cjs and esm in `@viem/anvil` package.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->